### PR TITLE
Manage notification state

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -7,7 +7,7 @@ const switchSession = (user) => {
   chrome.runtime.sendMessage(
     {
       method: 'setCookie',
-      data: { name: 'oauth_token', value: getSession(user) },
+      data: { name: 'oauth_token', value: getSession(user).cookie },
     }, () => parent.postMessage('_scam_reload', MESSAGE_ORIGIN),
   );
 };
@@ -52,9 +52,9 @@ window.addEventListener('message', (message) => {
   if (origin !== MESSAGE_ORIGIN) return;
 
   if (Array.isArray(data)) {
-    const [name, sessionData] = data;
+    const [name, sessionsData] = data;
     if (name === '_scam_sessions') {
-      sessions = sessionData;
+      sessions = sessionsData;
       injectLoggedOutSwitcher();
     }
   }

--- a/src/switcher.js
+++ b/src/switcher.js
@@ -11,11 +11,11 @@ const getCurrentUser = () => {
   return false;
 };
 
-const saveSession = (username, cookie) => {
+const saveSession = (username, sessionData) => {
   const obj = localStorage.hasOwnProperty('sc-accounts') ? JSON.parse(localStorage.getItem('sc-accounts')) : {};
-  const storedCookie = Object.keys(obj).find((user) => obj[user] === cookie);
+  const storedCookie = Object.keys(obj).find((user) => obj[user].cookie === sessionData.cookie);
   if (storedCookie && username !== storedCookie) delete obj[storedCookie];
-  obj[username] = cookie;
+  obj[username] = sessionData;
   localStorage.setItem('sc-accounts', JSON.stringify(obj));
 };
 
@@ -29,17 +29,29 @@ const deleteSession = (username) => {
 
 const saveCurrentSession = () => {
   const username = getCurrentUser();
+
+  const sessionData = getSession(username) || {};
+  sessionData.notifyState = localStorage.getItem('V2::local::notify');
+  saveSession(username, sessionData);
+
   if (previousUser === username || !username) return;
   previousUser = username;
   chrome.runtime.sendMessage({ method: 'getCookie', data: { name: 'oauth_token' } }, (data) => {
     const cookie = data ? data.value : null;
-    if (cookie) saveSession(username, cookie);
+    if (!cookie) return;
+
+    sessionData.cookie = cookie;
+    saveSession(username, sessionData);
   });
 };
 
 const switchSession = (user) => {
   saveCurrentSession();
-  chrome.runtime.sendMessage({ method: 'setCookie', data: { name: 'oauth_token', value: getSession(user) } }, () => {
+
+  const sessionData = getSession(user);
+  if (sessionData.notifyState != null) localStorage.setItem('V2::local::notify', sessionData.notifyState);
+
+  chrome.runtime.sendMessage({ method: 'setCookie', data: { name: 'oauth_token', value: sessionData.cookie } }, () => {
     location.reload();
   });
 };
@@ -163,6 +175,13 @@ window.addEventListener('message', (message) => {
 }, false);
 
 const init = () => {
+  // Migrate from old user sessions format
+  const sessions = localStorage.hasOwnProperty('sc-accounts') ? JSON.parse(localStorage.getItem('sc-accounts')) : {};
+  Object.keys(sessions).forEach(username => {
+    if (typeof sessions[username] === 'string') sessions[username] = { cookie: sessions[username] }
+  })
+  localStorage.setItem('sc-accounts', JSON.stringify(sessions))
+
   const observerOptions = { childList: true, subtree: true };
   menuObserver.observe(document.body, observerOptions);
   saveCurrentSession();

--- a/src/switcher.js
+++ b/src/switcher.js
@@ -177,10 +177,10 @@ window.addEventListener('message', (message) => {
 const init = () => {
   // Migrate from old user sessions format
   const sessions = localStorage.hasOwnProperty('sc-accounts') ? JSON.parse(localStorage.getItem('sc-accounts')) : {};
-  Object.keys(sessions).forEach(username => {
-    if (typeof sessions[username] === 'string') sessions[username] = { cookie: sessions[username] }
-  })
-  localStorage.setItem('sc-accounts', JSON.stringify(sessions))
+  Object.keys(sessions).forEach((username) => {
+    if (typeof sessions[username] === 'string') sessions[username] = { cookie: sessions[username] };
+  });
+  localStorage.setItem('sc-accounts', JSON.stringify(sessions));
 
   const observerOptions = { childList: true, subtree: true };
   menuObserver.observe(document.body, observerOptions);


### PR DESCRIPTION
Fixes #13

This requires sessions to be stored as objects rather than strings, so I included a migration routine inside `init`